### PR TITLE
Simplify handling of spaces in simple exporter

### DIFF
--- a/src/exporters/simpleexporter.cpp
+++ b/src/exporters/simpleexporter.cpp
@@ -17,7 +17,7 @@ bool SimpleExporter::Export(QByteArray &out)
     // Font size
     out.append(QString::number(cfg->size()).toUtf8()).append(' ');
     // Line height
-    out.append(QString::number(height).toUtf8()).append(' ');
+    out.append(QString::number(height).toUtf8()).append('\n');
     // Texture filename
     out.append(texFilename().toUtf8()).append('\n');
     // Number of symbols


### PR DESCRIPTION
Made exporter put font family and texture filename on their own line to make it easier to parse them if they contain spaces.
