### PR TITLE
Add option to specify freetype hinting algorithm

### DIFF
--- a/src/fontbuilder.ui
+++ b/src/fontbuilder.ui
@@ -25,7 +25,7 @@
        <locale language="English" country="UnitedStates"/>
       </property>
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="tab_Font">
        <attribute name="title">
@@ -156,7 +156,7 @@
     <item>
      <widget class="QTabWidget" name="tabWidget_2">
       <property name="currentIndex">
-       <number>0</number>
+       <number>1</number>
       </property>
       <widget class="QWidget" name="tab_Preview">
        <attribute name="title">
@@ -173,8 +173,8 @@
             <rect>
              <x>0</x>
              <y>0</y>
-             <width>246</width>
-             <height>406</height>
+             <width>360</width>
+             <height>425</height>
             </rect>
            </property>
            <layout class="QGridLayout" name="gridLayout">
@@ -318,7 +318,7 @@
      <x>0</x>
      <y>0</y>
      <width>612</width>
-     <height>22</height>
+     <height>19</height>
     </rect>
    </property>
    <widget class="QMenu" name="menu_File">

--- a/src/fontconfig.cpp
+++ b/src/fontconfig.cpp
@@ -44,6 +44,7 @@ FontConfig::FontConfig(QObject *parent) :
     m_hinting = HintingDefault;
     m_render_missing = false;
     m_antialiased = true;
+    m_aamethod = AAliasingNormal;
     m_bold = 0;
     m_italic = false;
     m_width = 100.0f;
@@ -125,6 +126,13 @@ void FontConfig::setHinting(int h) {
 void FontConfig::setAntialiased(bool b) {
     if (m_antialiased!=b) {
         m_antialiased = b;
+        renderingOptionsChanged();
+    }
+}
+
+void FontConfig::setAntiAliasing(int b) {
+    if (m_aamethod!=b) {
+        m_aamethod = b;
         renderingOptionsChanged();
     }
 }

--- a/src/fontconfig.h
+++ b/src/fontconfig.h
@@ -38,6 +38,7 @@ class FontConfig : public QObject
 {
 Q_OBJECT
 Q_ENUMS(HintingMethod)
+Q_ENUMS(AAMethod)
 public:
     explicit FontConfig(QObject *parent = 0);
 
@@ -48,6 +49,13 @@ public:
         HintingDefault,
         HintingForceFreetypeAuto,
         HintingDisableFreetypeAuto
+    };
+
+    enum AAMethod {
+        AAliasingNormal,
+        AAliasingLight,
+        AAliasingLCDhor,
+        AAliasingLCDvert
     };
 
     const QString& path() const { return m_path; }
@@ -93,6 +101,11 @@ public:
     void setAntialiased(bool b);
     Q_PROPERTY( bool antialiased READ antialiased WRITE setAntialiased )
 
+    int antialiasing() const { return m_aamethod;}
+    void setAntiAliasing(int b);
+    void resetAntiAliasing() {m_aamethod = AAliasingNormal;}
+    Q_PROPERTY( int antialiasing READ antialiasing WRITE setAntiAliasing RESET resetAntiAliasing)
+
     int bold() const { return m_bold;}
     void setBold(int b);
     Q_PROPERTY( int bold READ bold WRITE setBold )
@@ -134,6 +147,7 @@ private:
     int    m_hinting;
     bool    m_render_missing;
     bool    m_antialiased;
+    int     m_aamethod;
     int    m_bold;
     int    m_italic;
     float   m_width;

--- a/src/fontoptionsframe.cpp
+++ b/src/fontoptionsframe.cpp
@@ -61,6 +61,7 @@ void FontOptionsFrame::setConfig(FontConfig *config) {
     m_config = config;
     if (config) {
         ui->comboBox_Hinting->setCurrentIndex(m_config->hinting());
+        ui->comboBoxAA->setCurrentIndex(m_config->antialiasing());
         ui->checkBoxMissingGlypths->setChecked(m_config->renderMissing());
         ui->checkBoxSmoothing->setChecked(m_config->antialiased());
         ui->horizontalSliderBold->setValue(m_config->bold());
@@ -139,4 +140,9 @@ void FontOptionsFrame::on_comboBoxDPI_currentIndexChanged(QString val)
 void FontOptionsFrame::on_comboBox_Hinting_currentIndexChanged(int index)
 {
     if (index>=0) if (m_config) m_config->setHinting(static_cast<FontConfig::HintingMethod>(index));
+}
+
+void FontOptionsFrame::on_comboBoxAA_currentIndexChanged(int index)
+{
+    if (index>0) if (m_config) m_config->setAntiAliasing(static_cast<FontConfig::AAMethod>(index));
 }

--- a/src/fontoptionsframe.h
+++ b/src/fontoptionsframe.h
@@ -65,6 +65,7 @@ private slots:
     void on_checkBoxMissingGlypths_toggled(bool checked);
     void on_checkBoxAutohinting_toggled(bool checked);
     void on_comboBox_Hinting_currentIndexChanged(int index);
+    void on_comboBoxAA_currentIndexChanged(int index);
 };
 
 #endif // FONTOPTIONSFRAME_H

--- a/src/fontoptionsframe.ui
+++ b/src/fontoptionsframe.ui
@@ -40,6 +40,13 @@
    </property>
    <item>
     <layout class="QGridLayout" name="gridLayout_4">
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="checkBoxSmoothing">
+       <property name="text">
+        <string>Smoothing</string>
+       </property>
+      </widget>
+     </item>
      <item row="1" column="2" colspan="3">
       <widget class="QCheckBox" name="checkBoxMissingGlypths">
        <property name="text">
@@ -135,11 +142,28 @@
        </item>
       </widget>
      </item>
-     <item row="0" column="0" colspan="2">
-      <widget class="QCheckBox" name="checkBoxSmoothing">
-       <property name="text">
-        <string>Smoothing</string>
-       </property>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="comboBoxAA">
+       <item>
+        <property name="text">
+         <string>Standard-grayscale</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Light</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>LCD horizontal</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>LCD vertical</string>
+        </property>
+       </item>
       </widget>
      </item>
     </layout>

--- a/src/fontrenderer.cpp
+++ b/src/fontrenderer.cpp
@@ -119,7 +119,22 @@ void FontRenderer::rasterize() {
         if (!m_config->antialiased()) {
             flags = flags | FT_LOAD_MONOCHROME | FT_LOAD_TARGET_MONO;
         } else {
-            flags = flags | FT_LOAD_TARGET_NORMAL;
+            switch (m_config->antialiasing()) {
+            case FontConfig::AAliasingNormal:
+                flags |= FT_LOAD_TARGET_NORMAL;
+                break;
+            case FontConfig::AAliasingLight:
+                flags |= FT_LOAD_TARGET_LIGHT;
+                break;
+            case FontConfig::AAliasingLCDhor:
+                flags |= FT_LOAD_TARGET_LCD;
+                break;
+            case FontConfig::AAliasingLCDvert:
+                flags |= FT_LOAD_TARGET_LCD_V;
+                break;
+            default:
+                break;
+            }
         }
         switch (m_config->hinting()) {
         case  FontConfig::HintingDisable:


### PR DESCRIPTION
This adds a new combobox besides the 'Smoothing' checkbox.
It lets you specify the hinting algorithm used by freetype.
For small font sizes especially options like "LCD" improve readability. Tested with a small Oled grayscale display.
