### PR TITLE
Enable size field  again after selecting a fixed size font

### DIFF
--- a/src/fontselectframe.cpp
+++ b/src/fontselectframe.cpp
@@ -330,6 +330,7 @@ void FontSelectFrame::readFontSizes(const FontDef& def) {
         for (size_t i=0;i<sizeof(sizes)/sizeof(sizes[0]);i++)
             ui->comboBoxSize->addItem(QString().number(
                     sizes[i]));
+        ui->comboBoxSize->setEnabled(true);
         ui->comboBoxSize->setEditable(true);
     }
     if (index>=0 )


### PR DESCRIPTION
Selecting a fixed size font and going back would make you unable to change the size after selecting a normal font again