### PR TITLE
Fix a small typo in the Output tab: “Getnerate x2” -> “Generate x2”

### DIFF
--- a/src/outputframe.ui
+++ b/src/outputframe.ui
@@ -185,7 +185,7 @@
    <item row="2" column="0" colspan="2">
     <widget class="QCheckBox" name="checkBoxGenerateX2">
      <property name="text">
-      <string>Getnerate x2</string>
+      <string>Generate x2</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Enables building on OSX+Homebrew (an alternative to MacPorts).