### PR TITLE
Change yoffset calculation in Simple/.sfl exporter to be similar to BMFont

### DIFF
--- a/src/exporters/simpleexporter.cpp
+++ b/src/exporters/simpleexporter.cpp
@@ -30,7 +30,7 @@ bool SimpleExporter::Export(QByteArray &out)
         out.append(QString::number(c.placeW).toUtf8()).append(' ');
         out.append(QString::number(c.placeH).toUtf8()).append(' ');
         out.append(QString::number(c.offsetX).toUtf8()).append(' ');
-        out.append(QString::number(height - c.offsetY).toUtf8()).append(' ');
+        out.append(QString::number(metrics().ascender - c.offsetY).toUtf8()).append(' ');
         out.append(QString::number(c.advance).toUtf8()).append(' ');
         out.append('\n');
     }


### PR DESCRIPTION
Currently the yoffset is calculated differently to how it is calculated in BMFont. I could not figure out a reason for this, and on top of it, I could not figure out how to calculate the same yoffset from this export, without making this change.